### PR TITLE
Refine hero image without bundled asset

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,13 @@
         <a class="hero__brand" href="#">C· CAROLINE DENERVAUD</a>
         <a class="hero__menu" href="#">menú</a>
       </nav>
-      <div class="hero__image" role="img" aria-label="Composición de rocas"></div>
+      <div class="hero__image">
+        <img
+          src="assets/portada-rocas.jpg"
+          alt="Composición de rocas sin tipografía"
+          loading="lazy"
+        />
+      </div>
       <footer class="hero__footer">
         <span>hoja azul</span>
         <span>1 / 2</span>

--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,4 @@
 :root {
-  --hero-image: url("assets/portada-rocas.jpg");
   --background-color: #ffffff;
   --text-color: #111111;
   --muted-color: #555555;
@@ -59,11 +58,28 @@ body {
 }
 
 .hero__image {
-  background-image: var(--hero-image);
-  background-size: cover;
-  background-position: center;
+  position: relative;
   border-radius: 1.5rem;
   box-shadow: 0 40px 80px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
+  isolation: isolate;
+  min-height: clamp(420px, 60vh, 860px);
+}
+
+.hero__image img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(0.65) brightness(1.25) contrast(0.95);
+  transform: scale(1.01);
+}
+
+@media (max-width: 768px) {
+  .hero__image {
+    min-height: clamp(320px, 50vh, 640px);
+  }
 }
 
 .hero__footer {


### PR DESCRIPTION
## Summary
- render the hero artwork with an inline `<img>` element so the pale filter is applied via CSS filters instead of pseudo-element overlays
- remove the bundled PNG asset and keep the layout ready for a user-provided photograph referenced from `index.html`
- update customization instructions to explain how to swap the image source manually

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d462f8c8a08330a9a0f6e4cca10d0d